### PR TITLE
Replaced i.e. with e.g. It's an example, not an explanation.

### DIFF
--- a/bashshot.conf
+++ b/bashshot.conf
@@ -4,7 +4,7 @@
 # 		-----------------------
 
 
-# Enter filesystems to snapshot as a space separated string, i. e.:
+# Enter filesystems to snapshot as a space separated string, e.g.:
 # filesystems="poolx/fs1 pooly/fs2"
 filesystems=""
 


### PR DESCRIPTION
Det är ett exempel vi skriver, inte en förklaring.
